### PR TITLE
Add autocomplete session

### DIFF
--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
@@ -69,6 +69,7 @@ public class RNGooglePlacesModule extends ReactContextBaseJavaModule implements 
     private List<Place.Field> lastSelectedFields;
     public static final String TAG = "RNGooglePlaces";
     private PlacesClient placesClient;
+    private AutocompleteSessionToken sessionToken;
 
     public static int AUTOCOMPLETE_REQUEST_CODE = 360;
     public static String REACT_CLASS = "RNGooglePlaces";
@@ -120,6 +121,16 @@ public class RNGooglePlacesModule extends ReactContextBaseJavaModule implements 
     /**
      * Exposed React's methods
      */
+
+    @ReactMethod
+    public void beginAutocompleteSession() {
+        sessionToken = AutocompleteSessionToken.newInstance();
+    }
+
+    @ReactMethod
+    public void cancelAutocompleteSession() {
+        sessionToken = null;
+    }
 
     @ReactMethod
     public void openAutocompleteModal(ReadableMap options, ReadableArray fields, final Promise promise) {
@@ -233,8 +244,8 @@ public class RNGooglePlacesModule extends ReactContextBaseJavaModule implements 
             
         requestBuilder.setTypeFilter(getFilterType(type));
 
-        if (useSessionToken) {
-            requestBuilder.setSessionToken(AutocompleteSessionToken.newInstance());
+        if (sessionToken != null) {
+            requestBuilder.setSessionToken(sessionToken);
         }
             
         Task<FindAutocompletePredictionsResponse> task =

--- a/index.js
+++ b/index.js
@@ -49,6 +49,14 @@ class RNGooglePlaces {
 	getCurrentPlace(placeFields = []) {
 		return RNGooglePlacesNative.getCurrentPlace([...RNGooglePlaces.placeFieldsDefaults, ...placeFields])
 	}
+
+	beginAutocompleteSession() {
+		return RNGooglePlacesNative.beginAutocompleteSession();
+	}
+
+	cancelAutocompleteSession() {
+		return RNGooglePlacesNative.cancelAutocompleteSession();
+	}
 }
 
 export default new RNGooglePlaces()

--- a/ios/RNGooglePlaces.m
+++ b/ios/RNGooglePlaces.m
@@ -14,6 +14,7 @@
 
 @property (strong, nonatomic) CLLocationManager *locationManager;
 @property GMSAutocompleteBoundsMode boundsMode;
+@property GMSAutocompleteSessionToken *sessionToken;
 
 @end
 
@@ -50,6 +51,18 @@ RCT_EXPORT_MODULE()
 - (void)dealloc
 {
     self.locationManager = nil;
+}
+
+RCT_EXTERN_METHOD(beginAutocompleteSession);
+- (void)beginAutocompleteSession
+{
+    self.sessionToken = [GMSAutocompleteSessionToken new];
+}
+
+RCT_EXTERN_METHOD(cancelAutocompleteSession);
+- (void)cancelAutocompleteSession
+{
+    self.sessionToken = nil;
 }
 
 RCT_EXPORT_METHOD(openAutocompleteModal: (NSDictionary *)options
@@ -95,13 +108,11 @@ RCT_EXPORT_METHOD(getAutocompletePredictions: (NSString *)query
     
     GMSCoordinateBounds *autocompleteBounds = [self getBounds:locationBias andRestrictOptions:locationRestriction];
     
-    GMSAutocompleteSessionToken *token = [[GMSAutocompleteSessionToken alloc] init];
-    
     [[GMSPlacesClient sharedClient] findAutocompletePredictionsFromQuery:query
                                                bounds:autocompleteBounds
                                                boundsMode:self.boundsMode
                                                filter:autocompleteFilter
-                                               sessionToken:token
+                                               sessionToken:self.sessionToken
                                              callback:^(NSArray<GMSAutocompletePrediction *> * _Nullable results, NSError *error) {
                                                  if (error != nil) {
                                                      reject(@"E_AUTOCOMPLETE_ERROR", [error description], nil);


### PR DESCRIPTION
Added new method `beginAutocompleteSession`
We had to add this method because the way it is today, a new token is created for every call to autoCompletePredictions which means every character typed on the client generates a new token.