### PR TITLE
Bump google maps

### DIFF
--- a/ios/NSMutableDictionary+GMSPlace.m
+++ b/ios/NSMutableDictionary+GMSPlace.m
@@ -47,16 +47,6 @@
     if (place.rating) {
         placeData[@"rating"] = [NSNumber numberWithDouble:place.rating];
     }
-    
-    if (place.viewport) {
-        NSMutableDictionary *viewportMap = [[NSMutableDictionary alloc] init];
-        viewportMap[@"latitudeNE"] = [NSNumber numberWithDouble:place.viewport.northEast.latitude];
-        viewportMap[@"longitudeNE"] = [NSNumber numberWithDouble:place.viewport.northEast.longitude];
-        viewportMap[@"latitudeSW"] = [NSNumber numberWithDouble:place.viewport.southWest.latitude];
-        viewportMap[@"longitudeSW"] = [NSNumber numberWithDouble:place.viewport.southWest.longitude];
-
-        placeData[@"viewport"] = viewportMap;
-    }
 
     if (place.plusCode) {
         NSMutableDictionary *plusCodeMap = [[NSMutableDictionary alloc] init];

--- a/ios/RNGooglePlaces.h
+++ b/ios/RNGooglePlaces.h
@@ -10,7 +10,6 @@
 
 - (GMSPlacesAutocompleteTypeFilter) getFilterType:(NSString *)type;
 - (GMSPlaceField) getSelectedFields:(NSArray *)fields isCurrentOrFetchPlace:(Boolean)currentOrFetch;
-- (GMSCoordinateBounds *) getBounds: (NSDictionary *)biasOptions andRestrictOptions: (NSDictionary *)restrictOptions;
 
 @end
   

--- a/ios/RNGooglePlacesViewController.h
+++ b/ios/RNGooglePlacesViewController.h
@@ -11,8 +11,6 @@
 
 - (void)openAutocompleteModal: (GMSAutocompleteFilter *)autocompleteFilter
                   placeFields: (GMSPlaceField)selectedFields
-                       bounds: (GMSCoordinateBounds *)autocompleteBounds
-                   boundsMode: (GMSAutocompleteBoundsMode)autocompleteBoundsMode
                      resolver: (RCTPromiseResolveBlock)resolve
                      rejecter: (RCTPromiseRejectBlock)reject;
                      

--- a/ios/RNGooglePlacesViewController.m
+++ b/ios/RNGooglePlacesViewController.m
@@ -26,8 +26,6 @@
 
 - (void)openAutocompleteModal: (GMSAutocompleteFilter *)autocompleteFilter
                     placeFields: (GMSPlaceField)selectedFields
-                       bounds: (GMSCoordinateBounds *)autocompleteBounds
-                       boundsMode: (GMSAutocompleteBoundsMode)autocompleteBoundsMode
                      resolver: (RCTPromiseResolveBlock)resolve
                      rejecter: (RCTPromiseRejectBlock)reject;
 {
@@ -36,8 +34,6 @@
     
     GMSAutocompleteViewController *viewController = [[GMSAutocompleteViewController alloc] init];
     viewController.autocompleteFilter = autocompleteFilter;
-    viewController.autocompleteBounds = autocompleteBounds;
-    viewController.autocompleteBoundsMode = autocompleteBoundsMode;
     viewController.placeFields = selectedFields;
 	viewController.delegate = self;
     UIViewController *topController = [self getTopController];

--- a/react-native-google-places.podspec
+++ b/react-native-google-places.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage       = 'https://github.com/tolu360/react-native-google-places'
   s.source         = { :git => 'https://github.com/tolu360/react-native-google-places.git', :tag => s.version }
 
-  s.platform       = :ios, '9.0'
+  s.platform       = :ios, '11.0'
 
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-DHAVE_GOOGLE_MAPS=1', '-fno-modules'
 
   s.dependency 'React'
-  s.dependency 'GooglePlaces', '~> 3.2.0'
-  s.dependency 'GoogleMaps', '~> 3.2.0'
+  s.dependency 'GooglePlaces', '5.1.0'
+  s.dependency 'GoogleMaps', '5.1.0'
 end


### PR DESCRIPTION
Updated the GoogleMaps version to 5.0.1 and the GooglePlaces version to 5.0.1.

Due to the update, it was necessary to remove some methods that became deprecated from version 5.0.0.

Due to the update to version 5.0.1 of maps, it was necessary to update the iOS version to 11.

![Captura de Tela 2022-02-22 às 13 25 30](https://user-images.githubusercontent.com/98053923/155202570-440049d3-7519-4e73-9616-6031354992e4.png)


