### PR TITLE
[CODEME-1071] - Fixing missing old android volley version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,10 @@ dependencies {
     def supportLibVersion = safeExtGet('supportLibVersion', DEFAULT_SUPPORT_LIB_VERSION)
 
     implementation "com.facebook.react:react-native:+"
-    implementation "com.google.android.libraries.places:places:1.1.0"
+    implementation('com.google.android.libraries.places:places:1.1.0') {
+      exclude group: 'com.android.volley'
+    }
+    implementation 'com.android.volley:volley:1.2.0'
     implementation "com.android.support:appcompat-v7:${supportLibVersion}"
     implementation "com.android.support:support-v4:${supportLibVersion}"
     implementation "com.google.code.findbugs:jsr305:3.0.2"


### PR DESCRIPTION
We're having build errors on Android due to a missing old volley lib version.
There's also an issue on this lib repository: https://github.com/tolu360/react-native-google-places/issues/301