### PR TITLE
make Androidx-compliant

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,5 @@ dependencies {
       exclude group: 'com.android.volley'
     }
     implementation 'com.android.volley:volley:1.2.0'
-    implementation "com.android.support:appcompat-v7:${supportLibVersion}"
-    implementation "com.android.support:support-v4:${supportLibVersion}"
     implementation "com.google.code.findbugs:jsr305:3.0.2"
 }

--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesModule.java
@@ -8,10 +8,10 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.Manifest.permission;
 import android.content.pm.PackageManager;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
-import android.support.v4.content.ContextCompat;
-import 	android.support.v4.app.ActivityCompat;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
+import androidx.core.content.ContextCompat;
+import androidx.core.app.ActivityCompat;
 
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static android.Manifest.permission.ACCESS_WIFI_STATE;

--- a/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesPlaceFieldEnum.java
+++ b/android/src/main/java/com/arttitude360/reactnative/rngoogleplaces/RNGooglePlacesPlaceFieldEnum.java
@@ -1,7 +1,7 @@
 package com.arttitude360.reactnative.rngoogleplaces;
 
 import android.util.SparseArray;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.google.android.libraries.places.api.model.Place;
 


### PR DESCRIPTION
We're having Android build errors on Gympass's app due to the removal of `jetifier` package ([not needed since the 0.60](https://www.npmjs.com/package/jetifier#user-content-do-you-need-this) rn version) on the react-native upgrade initiative.